### PR TITLE
Add API endpoint for creating referral links from RapidPro webhooks

### DIFF
--- a/nurseconnect_registration/settings.py
+++ b/nurseconnect_registration/settings.py
@@ -46,6 +46,8 @@ INSTALLED_APPS = [
     "registrations",
     "django_prometheus",
     "watchman",
+    "rest_framework",
+    "rest_framework.authtoken",
 ]
 
 MIDDLEWARE = [
@@ -130,3 +132,11 @@ STATIC_URL = "/static/"
 WATCHMAN_TOKENS = env("WATCHMAN_TOKENS", str, "REPLACEME")
 WATCHMAN_TOKEN_NAME = "token"
 WATCHMAN_CHECKS = ("watchman.checks.databases",)
+
+REST_FRAMEWORK = {
+    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.TokenAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+    ),
+}

--- a/nurseconnect_registration/urls.py
+++ b/nurseconnect_registration/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 from django_prometheus.exports import ExportToDjangoView as metrics
+from rest_framework.documentation import include_docs_urls
 
 from nurseconnect_registration.decorators import internal_only
 
@@ -23,5 +24,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("metrics", internal_only(metrics), name="metrics"),
     path("health/", include(("watchman.urls", "health"))),
+    path("api-auth", include("rest_framework.urls")),
+    path("api/docs/", include_docs_urls(title="NurseConnect Registration")),
     path("", include(("registrations.urls", "registrations"))),
 ]

--- a/registrations/api_tests.py
+++ b/registrations/api_tests.py
@@ -1,0 +1,66 @@
+from django.contrib.auth.models import User, Permission
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from registrations.models import ReferralLink
+
+
+class ReferralLinkApiTests(APITestCase):
+    def test_authentication_required(self):
+        """
+        Authentication is required for this endpoint
+        """
+        r = self.client.post(reverse("registrations:referrallink-list"))
+        self.assertEqual(r.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_permission_required(self):
+        """
+        You must have the create referral link permission for this endpoint.
+        """
+        user = User.objects.create_user("test")
+        self.client.force_login(user)
+        r = self.client.post(reverse("registrations:referrallink-list"))
+        self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_new_referral_link(self):
+        """
+        If a referral link for the given MSISDN doesn't exist, it should be created
+        """
+        self.assertEqual(ReferralLink.objects.count(), 0)
+        user = User.objects.create_user("test")
+        permission = Permission.objects.get(name="Can add referral link")
+        user.user_permissions.add(permission)
+        user.save()
+        self.client.force_login(user)
+
+        r = self.client.post(
+            reverse("registrations:referrallink-list"),
+            {"contact": {"urn": "tel:27820001001"}},
+            format="json",
+        )
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        [referral] = ReferralLink.objects.all()
+        self.assertIn(referral.path, r.data["referral_link"])
+
+    def test_existing_referral_link(self):
+        """
+        If a referral link already exists for an URN, then a new one should not be
+        created
+        """
+        ReferralLink.objects.create(msisdn="+27820001001")
+        user = User.objects.create_user("test")
+        permission = Permission.objects.get(name="Can add referral link")
+        user.user_permissions.add(permission)
+        user.save()
+        self.client.force_login(user)
+
+        self.assertEqual(ReferralLink.objects.count(), 1)
+        r = self.client.post(
+            reverse("registrations:referrallink-list"),
+            {"contact": {"urn": "tel:27820001001"}},
+            format="json",
+        )
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        [referral] = ReferralLink.objects.all()
+        self.assertIn(referral.path, r.data["referral_link"])

--- a/registrations/api_tests.py
+++ b/registrations/api_tests.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.models import User, Permission
+from django.contrib.auth.models import Permission, User
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase

--- a/registrations/api_views.py
+++ b/registrations/api_views.py
@@ -1,0 +1,28 @@
+from rest_framework import permissions, viewsets
+from rest_framework.response import Response
+
+from registrations.models import ReferralLink
+from registrations.serializers import URN_REGEX, RapidProFlowWebHookSerializer
+from registrations.utils import normalise_msisdn
+
+
+class ReferralLinkViewSet(viewsets.GenericViewSet):
+    """
+    Allows the creating of referral links
+    """
+
+    serializer_class = RapidProFlowWebHookSerializer
+    queryset = ReferralLink.objects.all()
+    permission_classes = (permissions.DjangoModelPermissions,)
+
+    def create(self, request):
+        """
+        Returns the full referral URI for the given MSISDN
+        """
+        serializer = self.get_serializer_class()(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        urn = serializer.validated_data["contact"]["urn"]
+        msisdn = URN_REGEX.match(urn).group("path")
+        msisdn = normalise_msisdn(msisdn)
+        referral, _ = ReferralLink.objects.get_or_create(msisdn=msisdn)
+        return Response({"referral_link": referral.build_uri(request)})

--- a/registrations/serializers.py
+++ b/registrations/serializers.py
@@ -1,0 +1,14 @@
+import re
+
+from rest_framework import serializers
+
+URN_REGEX = re.compile(r"^(?P<scheme>.+):(?P<path>.+)$")
+
+
+class RapidProFlowWebHookSerializer(serializers.Serializer):
+    class Contact(serializers.Serializer):
+        urn = serializers.RegexField(
+            URN_REGEX, help_text="The URN of the contact that triggered the flow"
+        )
+
+    contact = Contact(help_text="The contact that triggered the flow")

--- a/registrations/urls.py
+++ b/registrations/urls.py
@@ -1,11 +1,16 @@
-from django.urls import path
+from django.urls import include, path
+from rest_framework import routers
 
+from registrations.api_views import ReferralLinkViewSet
 from registrations.views import (
     RegistrationConfirmClinic,
     RegistrationDetailsView,
     RegistrationSuccess,
     TermsAndConditionsView,
 )
+
+api_router = routers.DefaultRouter()
+api_router.register("referral_link", ReferralLinkViewSet)
 
 urlpatterns = [
     path("", RegistrationDetailsView.as_view(), name="registration-details"),
@@ -16,5 +21,6 @@ urlpatterns = [
         TermsAndConditionsView.as_view(),
         name="terms_and_conditions",
     ),
+    path("api/v1/", include(api_router.urls)),
     path("<referral>", RegistrationDetailsView.as_view(), name="registration-details"),
 ]

--- a/registrations/utils.py
+++ b/registrations/utils.py
@@ -1,0 +1,6 @@
+import phonenumbers
+
+
+def normalise_msisdn(msisdn):
+    msisdn = phonenumbers.parse(msisdn, "ZA")
+    return phonenumbers.format_number(msisdn, phonenumbers.PhoneNumberFormat.E164)

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 max-line-length = 88
 
 [tool:pytest]
-python_files=nurseconnect_registration/test*.py registrations/test*.py
+python_files=nurseconnect_registration/test*.py registrations/*test*.py
 addopts = --verbose --ds=nurseconnect_registration.testsettings --ignore=ve --cov=nurseconnect_registration --cov=registrations --no-cov-on-fail
 
 [coverage:run]

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ setup(
         "django-prometheus==1.0.15",
         "django-watchman==0.16.0",
         "hashids==1.2.0",
+        "djangorestframework==3.9.2",
+        "coreapi==2.3.3",
     ],
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
This allows us to have RapidPro flows which can send the referral links to the users, so they can send them out to get registration referrals.